### PR TITLE
Fix undefined reference to _environ for libarm64

### DIFF
--- a/mingw-w64-crt/lib-common/msvcrt.def.in
+++ b/mingw-w64-crt/lib-common/msvcrt.def.in
@@ -473,6 +473,7 @@ _ecvt_s
 _endthread
 _endthreadex
 F_X86_ANY(_environ DATA)
+F_ARM64(_environ DATA)
 _eof
 _errno
 F_I386(_except_handler2)


### PR DESCRIPTION
Fixes undefined reference to `_environ` when building for `aarch64-w64-mingw32` host and target.