### PR TITLE
Add `aarch64-pc-cygwin-target`

### DIFF
--- a/mingw-w64-headers/crt/_cygwin.h
+++ b/mingw-w64-headers/crt/_cygwin.h
@@ -29,7 +29,7 @@
    The Cygwin-targeting gcc does not define it by default, same as
    with _WIN32.  Therefore we set it here.  The result is that _WIN64
    is only defined if Windows headers are included. */
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(__aarch64__)
 #define _WIN64
 #endif
 


### PR DESCRIPTION
This PR adds `aarch64-pc-cygwin` target support.

Tested by:   
- https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/12298556694  
- https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/12298556702