### PR TITLE
Add check if `libgcc` is available and link `winpthreads` against it instead of `fakelib`

### DIFF
--- a/mingw-w64-libraries/winpthreads/Makefile.am
+++ b/mingw-w64-libraries/winpthreads/Makefile.am
@@ -19,7 +19,9 @@ AM_CFLAGS += -nologo
 libwinpthread_la_CPPFLAGS += -D_CRT_NONSTDC_NO_WARNINGS
 else
 libwinpthread_la_CPPFLAGS += -D__USE_MINGW_ANSI_STDIO=0
-libwinpthread_la_LDFLAGS += -L$(builddir)/fakelib -Wc,-no-pthread
+if !HAVE_LIBGCC
+libwinpthread_la_LDFLAGS += -L$(builddir)/fakelib
+
 EXTRA_libwinpthread_la_DEPENDENCIES = fakelib/libgcc.a  fakelib/libgcc_eh.a  fakelib/libgcc_s.a
 
 # Break circular dep on bootstrap
@@ -27,6 +29,8 @@ noinst_LIBRARIES = fakelib/libgcc.a  fakelib/libgcc_eh.a  fakelib/libgcc_s.a
 fakelib_libgcc_a_SOURCES = src/libgcc/dll_dependency.S src/libgcc/dll_math.c
 fakelib_libgcc_s_a_SOURCES =
 fakelib_libgcc_eh_a_SOURCES =
+endif
+libwinpthread_la_LDFLAGS += -Wc,-no-pthread
 endif
 
 lib_LIBRARIES = 

--- a/mingw-w64-libraries/winpthreads/Makefile.in
+++ b/mingw-w64-libraries/winpthreads/Makefile.in
@@ -93,9 +93,10 @@ host_triplet = @host@
 @MSVC_TRUE@am__append_1 = -nologo
 @MSVC_TRUE@am__append_2 = -D_CRT_NONSTDC_NO_WARNINGS
 @MSVC_FALSE@am__append_3 = -D__USE_MINGW_ANSI_STDIO=0
-@MSVC_FALSE@am__append_4 = -L$(builddir)/fakelib -Wc,-no-pthread
-@COPY_STATIC_TRUE@am__append_5 = libpthread.a
-@COPY_SHARED_TRUE@am__append_6 = libpthread.dll.a
+@HAVE_LIBGCC_FALSE@@MSVC_FALSE@am__append_4 = -L$(builddir)/fakelib
+@MSVC_FALSE@am__append_5 = -Wc,-no-pthread
+@COPY_STATIC_TRUE@am__append_6 = libpthread.a
+@COPY_SHARED_TRUE@am__append_7 = libpthread.dll.a
 subdir = .
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
@@ -153,9 +154,8 @@ fakelib_libgcc_a_LIBADD =
 am__fakelib_libgcc_a_SOURCES_DIST = src/libgcc/dll_dependency.S \
 	src/libgcc/dll_math.c
 am__dirstamp = $(am__leading_dot)dirstamp
-@MSVC_FALSE@am_fakelib_libgcc_a_OBJECTS =  \
-@MSVC_FALSE@	src/libgcc/dll_dependency.$(OBJEXT) \
-@MSVC_FALSE@	src/libgcc/dll_math.$(OBJEXT)
+@HAVE_LIBGCC_FALSE@@MSVC_FALSE@am_fakelib_libgcc_a_OBJECTS = src/libgcc/dll_dependency.$(OBJEXT) \
+@HAVE_LIBGCC_FALSE@@MSVC_FALSE@	src/libgcc/dll_math.$(OBJEXT)
 fakelib_libgcc_a_OBJECTS = $(am_fakelib_libgcc_a_OBJECTS)
 fakelib_libgcc_eh_a_AR = $(AR) $(ARFLAGS)
 fakelib_libgcc_eh_a_LIBADD =
@@ -485,20 +485,20 @@ include_HEADERS = include/pthread.h include/sched.h include/semaphore.h include/
 libwinpthread_la_CPPFLAGS = -I$(srcdir)/include -DIN_WINPTHREAD \
 	-DWINPTHREAD_DBG=1 $(am__append_2) $(am__append_3)
 libwinpthread_la_LDFLAGS = -no-undefined -version-info 1:0:0 \
-	$(am__append_4)
+	$(am__append_4) $(am__append_5)
 libwinpthread_la_SOURCES = \
   src/barrier.h  src/cond.h  src/misc.h  src/mutex.h  src/rwlock.h  src/spinlock.h  src/thread.h  src/ref.h  src/sem.h  src/wpth_ver.h \
   src/barrier.c  src/cond.c  src/misc.c  src/mutex.c  src/rwlock.c  src/spinlock.c  src/thread.c  src/ref.c  src/sem.c  src/sched.c \
   src/winpthread_internal.h  src/clock.c src/nanosleep.c src/version.rc
 
-@MSVC_FALSE@EXTRA_libwinpthread_la_DEPENDENCIES = fakelib/libgcc.a  fakelib/libgcc_eh.a  fakelib/libgcc_s.a
+@HAVE_LIBGCC_FALSE@@MSVC_FALSE@EXTRA_libwinpthread_la_DEPENDENCIES = fakelib/libgcc.a  fakelib/libgcc_eh.a  fakelib/libgcc_s.a
 
 # Break circular dep on bootstrap
-@MSVC_FALSE@noinst_LIBRARIES = fakelib/libgcc.a  fakelib/libgcc_eh.a  fakelib/libgcc_s.a
-@MSVC_FALSE@fakelib_libgcc_a_SOURCES = src/libgcc/dll_dependency.S src/libgcc/dll_math.c
-@MSVC_FALSE@fakelib_libgcc_s_a_SOURCES = 
-@MSVC_FALSE@fakelib_libgcc_eh_a_SOURCES = 
-lib_LIBRARIES = $(am__append_5) $(am__append_6)
+@HAVE_LIBGCC_FALSE@@MSVC_FALSE@noinst_LIBRARIES = fakelib/libgcc.a  fakelib/libgcc_eh.a  fakelib/libgcc_s.a
+@HAVE_LIBGCC_FALSE@@MSVC_FALSE@fakelib_libgcc_a_SOURCES = src/libgcc/dll_dependency.S src/libgcc/dll_math.c
+@HAVE_LIBGCC_FALSE@@MSVC_FALSE@fakelib_libgcc_s_a_SOURCES = 
+@HAVE_LIBGCC_FALSE@@MSVC_FALSE@fakelib_libgcc_eh_a_SOURCES = 
+lib_LIBRARIES = $(am__append_6) $(am__append_7)
 @COPY_STATIC_TRUE@libpthread_a_SOURCES = 
 @COPY_STATIC_TRUE@libpthread_a_DEPENDENCIES = libwinpthread.la
 #FIXME: Use cp kludge until a better method presents itself

--- a/mingw-w64-libraries/winpthreads/configure
+++ b/mingw-w64-libraries/winpthreads/configure
@@ -657,6 +657,8 @@ ac_subst_vars='am__EXEEXT_FALSE
 am__EXEEXT_TRUE
 LTLIBOBJS
 LIBOBJS
+HAVE_LIBGCC_FALSE
+HAVE_LIBGCC_TRUE
 COPY_STATIC_FALSE
 COPY_STATIC_TRUE
 COPY_SHARED_FALSE
@@ -13843,6 +13845,65 @@ fi
 # FIXME: Replace `main' with a function in `-lpthread':
 #AC_CHECK_LIB([pthread], [main])
 
+# Check if libgcc is available
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for main in -lgcc" >&5
+printf %s "checking for main in -lgcc... " >&6; }
+if test ${ac_cv_lib_gcc_main+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lgcc  $LIBS"
+if test x$ac_no_link = xyes; then
+  as_fn_error $? "link tests are not allowed after AC_NO_EXECUTABLES" "$LINENO" 5
+fi
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+int
+main (void)
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_lib_gcc_main=yes
+else $as_nop
+  ac_cv_lib_gcc_main=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_gcc_main" >&5
+printf "%s\n" "$ac_cv_lib_gcc_main" >&6; }
+if test "x$ac_cv_lib_gcc_main" = xyes
+then :
+   if true ; then
+  HAVE_LIBGCC_TRUE=
+  HAVE_LIBGCC_FALSE='#'
+else
+  HAVE_LIBGCC_TRUE='#'
+  HAVE_LIBGCC_FALSE=
+fi
+
+else $as_nop
+   if false ; then
+  HAVE_LIBGCC_TRUE=
+  HAVE_LIBGCC_FALSE='#'
+else
+  HAVE_LIBGCC_TRUE='#'
+  HAVE_LIBGCC_FALSE=
+fi
+
+
+fi
+
+
 # Checks for header files.
 ac_fn_c_check_header_compile "$LINENO" "limits.h" "ac_cv_header_limits_h" "$ac_includes_default"
 if test "x$ac_cv_header_limits_h" = xyes
@@ -14075,6 +14136,14 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${COPY_STATIC_TRUE}" && test -z "${COPY_STATIC_FALSE}"; then
   as_fn_error $? "conditional \"COPY_STATIC\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${HAVE_LIBGCC_TRUE}" && test -z "${HAVE_LIBGCC_FALSE}"; then
+  as_fn_error $? "conditional \"HAVE_LIBGCC\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${HAVE_LIBGCC_TRUE}" && test -z "${HAVE_LIBGCC_FALSE}"; then
+  as_fn_error $? "conditional \"HAVE_LIBGCC\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 

--- a/mingw-w64-libraries/winpthreads/configure.ac
+++ b/mingw-w64-libraries/winpthreads/configure.ac
@@ -45,6 +45,13 @@ AM_CONDITIONAL( [COPY_STATIC], [AS_VAR_TEST_SET([copy_static])] )
 # FIXME: Replace `main' with a function in `-lpthread':
 #AC_CHECK_LIB([pthread], [main])
 
+# Check if libgcc is available
+AC_CHECK_LIB(
+  [gcc], [main],
+  [AM_CONDITIONAL( [HAVE_LIBGCC], [true] )],
+  [AM_CONDITIONAL( [HAVE_LIBGCC], [false] )]
+)
+
 # Checks for header files.
 AC_CHECK_HEADERS([limits.h sys/timeb.h])
 


### PR DESCRIPTION
`winpthreads` is linking against fake runtime library for stage 1 builds. During stage 2 when `libgcc` is already available, this i not needed.

This PR fixes https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/issues/208 and https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/pull/205.

Validated by https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/13951078487